### PR TITLE
if OID code in immunization, use makeQdmCode so system gets nulled ou…

### DIFF
--- a/src/Services/Qdm/Services/ImmunizationAdministeredService.php
+++ b/src/Services/Qdm/Services/ImmunizationAdministeredService.php
@@ -49,12 +49,20 @@ class ImmunizationAdministeredService extends AbstractQdmService implements QdmS
             }
         }
 
-        $model->addCode(
-            new Code([
-                'code' => $record['cvx_code'],
-                'system' => $this->getSystemForCodeType('CVX')
-            ])
-        );
+        if (strpos($record['cvx_code'], ':') !== false) {
+            // Use the make code that blanks out the OID portion, or creates a code with code type
+            $model->addCode($this->makeQdmCode($record['cvx_code']));
+        } else {
+            // We make the code manually here, not using makeQdmCode because we need to set the code system
+            $model->addCode(
+                new Code([
+                    'code' => $record['cvx_code'],
+                    'system' => $this->getSystemForCodeType('CVX')
+                ])
+            );
+
+        }
+
 
         return $model;
     }


### PR DESCRIPTION
@sjpadgett You may want to leave your fix, but we weren't calling the parent class makeQdmModel in immun service because we aren't passed a code type for immunization codes, and CVX code type had to be added. This should add a code type if we have a colon-separated code, otherwise it uses CVX
