### PR TITLE
Fix ccda author,custodian,config settings

### DIFF
--- a/ccdaservice/serveccda.js
+++ b/ccdaservice/serveccda.js
@@ -2353,8 +2353,8 @@ function populateHeader(pd) {
             },
             "identifiers": [
                 {
-                    "identifier": pd.author.id || "2.16.840.1.113883.4.6",
-                    "extension": !pd.author.id ? pd.author.npi : ''
+                    "identifier": pd.author.npi ? "2.16.840.1.113883.4.6" : pd.author.id,
+                        "extension": pd.author.npi ? pd.author.npi : ''
                 }
             ],
             "name": [

--- a/interface/modules/zend_modules/module/Application/view/application/sendto/send.phtml
+++ b/interface/modules/zend_modules/module/Application/view/application/sendto/send.phtml
@@ -182,12 +182,12 @@ $download_format = $this->download_format;
     </div>
     <div id="componentsForCCDA" style="height:300px !important;display:none;" class="ap-st-st-13">
         <div style="display:inline-flex;width:100%;">
-            <div style="width:35%">
-                <label><input class="ap-st-st-3" type="radio" name="downloadformat_type" id="downloadformat_toc" value="toc" checked>&nbsp;<?php echo $this->listenerObject->z_xlt('Transistion of Care') ?></label>
-            </div>
             <div style="width:15%">
-                <label style="margin:1px 2px;"><input class="ap-st-st-3" type="radio" name="downloadformat_type" id="downloadformat_ccd" value="ccd">&nbsp;<?php echo $this->listenerObject->z_xlt('CCD') ?></label>
+                <label style="margin:1px 2px;"><input class="ap-st-st-3" type="radio" name="downloadformat_type" id="downloadformat_ccd" value="ccd" checked>&nbsp;<?php echo $this->listenerObject->z_xlt('CCD') ?></label>
             </div>
+            <div style="width:35%">
+                <label><input class="ap-st-st-3" type="radio" name="downloadformat_type" id="downloadformat_toc" value="toc" >&nbsp;<?php echo $this->listenerObject->z_xlt('Transistion of Care') ?></label>
+            </div>N
             <div style="width:25%">
                 <label><input class="ap-st-st-3" type="radio" name="downloadformat_type" id="downloadformat_careplan" value="careplan">&nbsp;<?php echo $this->listenerObject->z_xlt('Careplan') ?></label>
             </div>

--- a/interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Form/ModuleconfigForm.php
+++ b/interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Form/ModuleconfigForm.php
@@ -204,6 +204,22 @@ class ModuleconfigForm extends Form
                     'value_options' => $this->getProviders(),
                 ),
             ));
+        $this->add(array(
+
+            'name' => 'hie_author_date',
+            'type' => 'Laminas\Form\Element\DateTimeLocal',
+            'attributes' => [
+                //'min' => '2000-01-01T00:00Z',
+                //'max' => '2030-01-01T00:00:00Z',
+                'step' => '1',
+                'id' => 'hie_author_date',
+            ],
+            'options' => array(
+                //'format' => 'Y-m-d\T:HP',
+                'label' => $this->zListener->z_xlt('Author Date')
+            ),
+
+        ));
     }
 
     /**


### PR DESCRIPTION
Made some changes to get things passing the ETT ccda validation.

Made it so the author npi works and that the author doesn't blow up when
it returns as a string.

Fixed issue with the custodian uuid accidently being set as the phone
number.

Added in the author date time stamp override in the config settings.