### PR TITLE
Ccda author encounter provenance flag

### DIFF
--- a/ccdaservice/oe-blue-button-generate/lib/documentLevel.js
+++ b/ccdaservice/oe-blue-button-generate/lib/documentLevel.js
@@ -64,7 +64,7 @@ exports.ccd2 = function (html_renderer) {
                 text: leafLevel.inputProperty("title"),
                 dataKey: "meta.ccda_header"
             },
-            [fieldLevel.effectiveDocumentTime, required], {
+            [fieldLevel.effectiveTime, required, dataKey("meta.ccda_header.date_time")], {
                 key: "confidentialityCode",
                 attributes: leafLevel.codeFromName("2.16.840.1.113883.5.25"),
                 dataKey: "meta.confidentiality"

--- a/ccdaservice/oe-blue-button-generate/lib/documentLevel.js
+++ b/ccdaservice/oe-blue-button-generate/lib/documentLevel.js
@@ -92,6 +92,7 @@ exports.ccd2 = function (html_renderer) {
             headerLevel.headerInformant,
             headerLevel.headerCustodian,
             headerLevel.headerInformationRecipient,
+            headerLevel.participant,
             headerLevel.providers, {
                 key: "component",
                 content: {

--- a/ccdaservice/oe-blue-button-generate/lib/fieldLevel.js
+++ b/ccdaservice/oe-blue-button-generate/lib/fieldLevel.js
@@ -142,6 +142,13 @@ var timeNow = exports.timeNow = {
     }
 };
 
+var timeDocumentTime = exports.timeDocumentTime = {
+    key: "time",
+    attributes: {
+        "value": leafLevel.time
+    }
+};
+
 var effectiveTime = exports.effectiveTime = {
     key: "effectiveTime",
     attributes: {
@@ -338,6 +345,32 @@ var assignedEntity = exports.assignedEntity = {
         representedOrganization
     ],
     existsWhen: condition.eitherKeyExists("address", "identifiers", "organization", "name")
+};
+
+var associatedEntity = exports.associatedEntity = {
+    key: "associatedEntity"
+    ,attributes: {
+        classCode: leafLevel.inputProperty("classCode"),
+    },
+    content: [
+        id,
+        {
+            key: "code",
+            attributes: leafLevel.code,
+            dataKey: "code"
+        },
+        usRealmAddress,
+        telecom,
+        {
+            key: "associatedPerson",
+            content: usRealmName,
+            existsWhen: condition.keyExists("name")
+            ,attributes: {
+                classCode: "PSN"
+                ,determinerCode: "INSTANCE"
+            }
+        }
+    ]
 };
 
 exports.author = {

--- a/ccdaservice/oe-blue-button-generate/lib/headerLevel.js
+++ b/ccdaservice/oe-blue-button-generate/lib/headerLevel.js
@@ -263,6 +263,19 @@ var providers = exports.providers = {
     dataKey: "data.demographics"
 };
 
+var participants = exports.participant = [{
+    key: "participant"
+    ,attributes: {
+        typeCode: leafLevel.inputProperty("typeCode")
+    }
+    ,content: [
+        [fieldLevel.effectiveTime, required, key("time")],
+        // associatedEntity
+        ,fieldLevel.associatedEntity
+    ]
+    ,dataKey: "meta.ccda_header.participants"
+}];
+
 var attributed_provider = exports.attributed_provider = {
     key: "providerOrganization",
     content: [{

--- a/ccdaservice/serveccda.js
+++ b/ccdaservice/serveccda.js
@@ -2308,7 +2308,7 @@ function populateNote(pd) {
     };
 }
 
-function populateOfficeParticipant(participant) {
+function populateParticipant(participant) {
     return {
         "name": {
             "prefix": participant.prefix || "",
@@ -2317,7 +2317,7 @@ function populateOfficeParticipant(participant) {
             "last": participant.lname || "",
             "first": participant.fname || ""
         },
-        "typeCode": "CALLBCK",
+        "typeCode": participant.type || "",
         "classCode": "ASSIGNED",
         "code": {
             "name": participant.organization_taxonomy_description || "",
@@ -2344,7 +2344,7 @@ function populateOfficeParticipant(participant) {
                 "state": participant.state,
                 "zip": participant.postalCode,
                 "country": participant.country || "US",
-                "use": "WP"
+                "use": participant.address_use || "WP"
             }
         ],
     }
@@ -2662,9 +2662,22 @@ function populateHeader(pd) {
         }*/
     };
     let participants = [];
-    if (pd.office_contact) {
-        participants.push(populateOfficeParticipant(pd.office_contact));
+    let docParticipants = pd.document_participants || {participant: []};
+    let count = 0;
+    try {
+        count = isOne(docParticipants.participant);
+    } catch (e) {
+        count = 0
     }
+    if (count == 1) {
+        participants = [populateParticipant(docParticipants.participant)];
+    } else {
+        // grab the values of our object
+        participants = Object.values(docParticipants.participant)
+                        .filter(pcpt => pcpt.type)
+                        .map(pcpt => populateParticipant(pcpt));
+    }
+
     if (participants.length) {
         head.participants = participants;
     }

--- a/ccdaservice/serveccda.js
+++ b/ccdaservice/serveccda.js
@@ -2389,10 +2389,10 @@ function populateHeader(pd) {
         },
         "title": name,
         "date_time": {
-            // php already sends this in YYYYMMDDHHmmss(+/-)zzzz format
-            // so we can just take it straight away for the document head
-            "date": pd.created_time_timezone,
-            "precision": "none"
+            "point": {
+                "date": fDate(pd.created_time_timezone),
+                "precision": "tz"
+            }
         },
         "author": {
             "date_time": {

--- a/ccdaservice/serveccda.js
+++ b/ccdaservice/serveccda.js
@@ -2335,6 +2335,12 @@ function populateParticipant(participant) {
                 "precision": "tz"
             }
         },
+        "phone": [
+            {
+                "number": participant.phonew1 || "",
+                "type": "WP"
+            }
+        ],
         "address": [
             {
                 "street_lines": [

--- a/ccdaservice/serveccda.js
+++ b/ccdaservice/serveccda.js
@@ -2353,8 +2353,8 @@ function populateHeader(pd) {
             },
             "identifiers": [
                 {
-                    "identifier": pd.author.id || "2.16.840.1.113883.4.6",
-                    "extension": !pd.author.id ? pd.author.npi : ''
+                    "identifier": pd.author.npi ? "2.16.840.1.113883.4.6" : pd.author.id,
+                        "extension": pd.author.npi ? pd.author.npi : ''
                 }
             ],
             "name": [

--- a/ccdaservice/serveccda.js
+++ b/ccdaservice/serveccda.js
@@ -2344,7 +2344,7 @@ function populateParticipant(participant) {
         "address": [
             {
                 "street_lines": [
-                    participant.streetAddressLine
+                    participant.street
                 ],
                 "city": participant.city,
                 "state": participant.state,

--- a/interface/modules/zend_modules/module/Application/view/application/sendto/send.phtml
+++ b/interface/modules/zend_modules/module/Application/view/application/sendto/send.phtml
@@ -187,7 +187,7 @@ $download_format = $this->download_format;
             </div>
             <div style="width:35%">
                 <label><input class="ap-st-st-3" type="radio" name="downloadformat_type" id="downloadformat_toc" value="toc" >&nbsp;<?php echo $this->listenerObject->z_xlt('Transistion of Care') ?></label>
-            </div>N
+            </div>
             <div style="width:25%">
                 <label><input class="ap-st-st-3" type="radio" name="downloadformat_type" id="downloadformat_careplan" value="careplan">&nbsp;<?php echo $this->listenerObject->z_xlt('Careplan') ?></label>
             </div>

--- a/interface/modules/zend_modules/module/Application/view/application/sendto/send.phtml
+++ b/interface/modules/zend_modules/module/Application/view/application/sendto/send.phtml
@@ -182,12 +182,12 @@ $download_format = $this->download_format;
     </div>
     <div id="componentsForCCDA" style="height:300px !important;display:none;" class="ap-st-st-13">
         <div style="display:inline-flex;width:100%;">
-            <div style="width:35%">
-                <label><input class="ap-st-st-3" type="radio" name="downloadformat_type" id="downloadformat_toc" value="toc" checked>&nbsp;<?php echo $this->listenerObject->z_xlt('Transistion of Care') ?></label>
-            </div>
             <div style="width:15%">
-                <label style="margin:1px 2px;"><input class="ap-st-st-3" type="radio" name="downloadformat_type" id="downloadformat_ccd" value="ccd">&nbsp;<?php echo $this->listenerObject->z_xlt('CCD') ?></label>
+                <label style="margin:1px 2px;"><input class="ap-st-st-3" type="radio" name="downloadformat_type" id="downloadformat_ccd" value="ccd" checked>&nbsp;<?php echo $this->listenerObject->z_xlt('CCD') ?></label>
             </div>
+            <div style="width:35%">
+                <label><input class="ap-st-st-3" type="radio" name="downloadformat_type" id="downloadformat_toc" value="toc" >&nbsp;<?php echo $this->listenerObject->z_xlt('Transistion of Care') ?></label>
+            </div>N
             <div style="width:25%">
                 <label><input class="ap-st-st-3" type="radio" name="downloadformat_type" id="downloadformat_careplan" value="careplan">&nbsp;<?php echo $this->listenerObject->z_xlt('Careplan') ?></label>
             </div>

--- a/interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Form/ModuleconfigForm.php
+++ b/interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Form/ModuleconfigForm.php
@@ -205,6 +205,18 @@ class ModuleconfigForm extends Form
                 ),
             ));
         $this->add(array(
+            'type' => 'Laminas\Form\Element\Checkbox',
+            'name' => 'hie_force_latest_encounter_provenance_date',
+            'attributes'    => array(
+                'id'        => 'hie_force_latest_encounter_provenance_date'
+            ),
+            'options' => array(
+                'label'         => $this->zListener->z_xlt('Force Provenance Author Date to be most recent encounter'),
+                'checked_value'     => 'yes',
+                'unchecked_value'   => 'no'
+            ),
+        ));
+        $this->add(array(
 
             'name' => 'hie_author_date',
             'type' => 'Laminas\Form\Element\DateTimeLocal',
@@ -216,9 +228,27 @@ class ModuleconfigForm extends Form
             ],
             'options' => array(
                 //'format' => 'Y-m-d\T:HP',
-                'label' => $this->zListener->z_xlt('Author Date')
+                'label' => $this->zListener->z_xlt('Provenance Author Date')
             ),
 
+        ));
+        /*
+        * Authenticator settings
+        */
+        $this->add(array(
+            'name'  => 'hie_office_contact',
+            'type'      => 'Laminas\Form\Element\Select',
+            'attributes' => array(
+                'class'     => '',
+                'data-options'  => 'required:true',
+                'editable'  => 'false',
+                'required'  => 'required',
+                'id'        => 'hie_office_contact'
+            ),
+            'options' => array(
+                'label'     => $this->zListener->z_xlt('Office Contact'),
+                'value_options' => $this->getUsers(),
+            ),
         ));
     }
 
@@ -231,7 +261,7 @@ class ModuleconfigForm extends Form
     public function getUsers()
     {
         $users = array('0' => '');
-        $res = $this->application->zQuery(("SELECT id, fname, lname, street, city, state, zip  FROM users WHERE abook_type='ccda'"));
+        $res = $this->application->zQuery(("SELECT id, fname, lname, street, city, state, zip  FROM users WHERE authorized=1 AND active='1' "));
         foreach ($res as $row) {
             $users[$row['id']] = $row['fname'] . " " . $row['lname'];
         }

--- a/interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Form/ModuleconfigForm.php
+++ b/interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Form/ModuleconfigForm.php
@@ -204,6 +204,22 @@ class ModuleconfigForm extends Form
                     'value_options' => $this->getProviders(),
                 ),
             ));
+        $this->add(array(
+
+            'name' => 'hie_author_date',
+            'type' => 'Laminas\Form\Element\DateTimeLocal',
+            'attributes' => [
+                //'min' => '2000-01-01T00:00Z',
+                //'max' => '2030-01-01T00:00:00Z',
+                'step' => '1',
+                'id' => 'hie_author_date',
+            ],
+            'options' => array(
+                //'format' => 'Y-m-d\T:HP',
+                'label' => $this->zListener->z_xlt('Author Date')
+            ),
+
+        ));
     }
 
     /**

--- a/interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Listener/CCDAEventsSubscriber.php
+++ b/interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Listener/CCDAEventsSubscriber.php
@@ -85,7 +85,7 @@ class CCDAEventsSubscriber implements EventSubscriberInterface
                 $event->getSectionsAsString(),
                 '',
                 [], // params appears to be used for the informationRecipient pieces, so we leaves this alone
-                'xml',
+                $event->getDocumentType(),
                 '',
                 $dates
             );

--- a/interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Model/CcdaServiceRequestModelGenerator.php
+++ b/interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Model/CcdaServiceRequestModelGenerator.php
@@ -18,6 +18,10 @@
 
 namespace Carecoordination\Model;
 
+use OpenEMR\Services\EncounterService;
+use OpenEMR\Services\PatientService;
+use OpenEMR\Validators\ProcessingResult;
+
 class CcdaServiceRequestModelGenerator
 {
     private $data;
@@ -48,6 +52,56 @@ class CcdaServiceRequestModelGenerator
         return $this->createdtime;
     }
 
+    private function get_service_start_dates($pid, $encounter, $document_type, $date_options) {
+        $start = $date_options['date_start'];
+        $end = $date_options['date_end'];
+        $document_type = $document_type ?? "ccd"; // default to ccd
+        if ($document_type == 'referral') {
+            // we are basing things on a single encounter so we need to try and grab our encounter date
+            if (!empty($encounter)) {
+                // we can adjust our dates here
+                // populate our dates based on our encounter
+                $encounterService = new EncounterService();
+                $encounterRecord = ProcessingResult::extractDataArray($encounterService->getEncounterById(intval($encounter)));
+                if (!empty($encounterRecord[0])) {
+                    $start = strtotime($encounterRecord[0]['date']);
+                    if (!empty($end)) {
+                        $end = strtotime($end);
+                        // TODO: if we add encounter end dates we can populate this
+                        $end = $end > $start ? $end : $start + 1800; // 30 minutes
+                    }
+                    $start = date('YmdHisO', $start);
+                    $end = date('YmdHisO', $end);
+                }
+            }
+        } else if ($document_type == 'ccd' || $document_type == 'toc') {
+            if (empty($end)) {
+                $end = date('YmdHisO'); // current date
+            }
+            if (empty($start) && !empty($pid)) {
+                $patientService = new PatientService();
+                $patientRecord = $patientService->findByPid($pid);
+                if (!empty($patientRecord)) {
+                    $start = date('YmdHisO', strtotime($patientRecord['DOB']));
+                }
+            }
+            if (empty($end) && !empty($pid)) {
+                $encounterId = $this->getEncounterccdadispatchTable()->getLatestEncounter($pid);
+                if (!empty($encounterId)) {
+                    $encounterService = new EncounterService();
+                    $encounterRecord = ProcessingResult::extractDataArray($encounterService->getEncounterById(intval($encounterId)));
+                    if (!empty($encounterRecord[0])) {
+                        $end = date('YmdHisO', strtotime($encounterRecord[0]['date']));
+                    }
+                }
+            }
+        }
+        return [
+            'start' => $start ?? date('YmdHisO')
+            ,'end' => $end ?? date('YmdHisO')
+        ];
+    }
+
     public function create_data($pid, $encounter, $sections, $components, $recipients, $params, $document_type, $referral_reason, int $send = null, $date_options = [])
     {
         global $assignedEntity;
@@ -58,6 +112,9 @@ class CcdaServiceRequestModelGenerator
         if (!$send) {
             $send = 0;
         }
+
+        $serviceStartDates = $this->get_service_start_dates($pid, $encounter, $document_type, $date_options);
+
         $sections_list = explode('|', $sections);
         $components_list = explode('|', $components);
         $this->createdtime = time();
@@ -67,8 +124,8 @@ class CcdaServiceRequestModelGenerator
         $this->data .= "<username></username>";
         $this->data .= "<password></password>";
         $this->data .= "<hie>MyHealth</hie>";
-        $this->data .= "<time_start>" . ($date_options['date_start'] ?: date('YmdHisO')) . "</time_start>";
-        $this->data .= "<time_end>" . ($date_options['date_end'] ?: date('YmdHisO')) . "</time_end>";
+        $this->data .= "<time_start>" . xmlEscape($serviceStartDates['start']) . "</time_start>";
+        $this->data .= "<time_end>" . xmlEscape($serviceStartDates['end']) . "</time_end>";
         $this->data .= "<client_id></client_id>";
         $this->data .= "<created_time>" . date('YmdHis') . "</created_time>";
         $this->data .= "<created_time_timezone>" . date('YmdHisO') . "</created_time_timezone>";

--- a/interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Model/CcdaServiceRequestModelGenerator.php
+++ b/interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Model/CcdaServiceRequestModelGenerator.php
@@ -102,7 +102,7 @@ class CcdaServiceRequestModelGenerator
         $this->data .= $this->getEncounterccdadispatchTable()->getCustodian($pid, $encounter);
         $this->data .= $this->getEncounterccdadispatchTable()->getInformationRecipient($pid, $encounter, $recipients, $params);
         $this->data .= $this->getEncounterccdadispatchTable()->getLegalAuthenticator($pid, $encounter);
-        $this->data .= $this->getEncounterccdadispatchTable()->getOfficeContact($pid, $encounter);
+        $this->data .= $this->getEncounterccdadispatchTable()->getDocumentParticipants($pid, $encounter);
         $this->data .= $this->getEncounterccdadispatchTable()->getAuthenticator($pid, $encounter);
         $this->data .= $this->getEncounterccdadispatchTable()->getPrimaryCareProvider($pid, $encounter);
         /***************CCDA Header Information***************/

--- a/interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Model/CcdaServiceRequestModelGenerator.php
+++ b/interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Model/CcdaServiceRequestModelGenerator.php
@@ -102,6 +102,7 @@ class CcdaServiceRequestModelGenerator
         $this->data .= $this->getEncounterccdadispatchTable()->getCustodian($pid, $encounter);
         $this->data .= $this->getEncounterccdadispatchTable()->getInformationRecipient($pid, $encounter, $recipients, $params);
         $this->data .= $this->getEncounterccdadispatchTable()->getLegalAuthenticator($pid, $encounter);
+        $this->data .= $this->getEncounterccdadispatchTable()->getOfficeContact($pid, $encounter);
         $this->data .= $this->getEncounterccdadispatchTable()->getAuthenticator($pid, $encounter);
         $this->data .= $this->getEncounterccdadispatchTable()->getPrimaryCareProvider($pid, $encounter);
         /***************CCDA Header Information***************/

--- a/interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Model/CcdaServiceRequestModelGenerator.php
+++ b/interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Model/CcdaServiceRequestModelGenerator.php
@@ -52,7 +52,7 @@ class CcdaServiceRequestModelGenerator
         return $this->createdtime;
     }
 
-    private function get_service_start_dates($pid, $encounter, $document_type, $date_options) {
+    private function getServiceStartDates($pid, $encounter, $document_type, $date_options) {
         $start = $date_options['date_start'];
         $end = $date_options['date_end'];
         $document_type = $document_type ?? "ccd"; // default to ccd
@@ -96,6 +96,15 @@ class CcdaServiceRequestModelGenerator
                 }
             }
         }
+        // TODO: this is the result of late night coding, hopefully we can come and fix this to be better in the future
+        // we essentially need to handle the fall through case where we have a date range that's been sent us
+        // that's not in our timestamp format
+        if (strpos($start, "-") !== false) {
+            $start = date('YmdHisO', strtotime($start));
+        }
+        if (strpos($end, "-") !== false) {
+            $end = date('YmdHisO', strtotime($end));
+        }
         return [
             'start' => $start ?? date('YmdHisO')
             ,'end' => $end ?? date('YmdHisO')
@@ -113,7 +122,7 @@ class CcdaServiceRequestModelGenerator
             $send = 0;
         }
 
-        $serviceStartDates = $this->get_service_start_dates($pid, $encounter, $document_type, $date_options);
+        $serviceStartDates = $this->getServiceStartDates($pid, $encounter, $document_type, $date_options);
 
         $sections_list = explode('|', $sections);
         $components_list = explode('|', $components);

--- a/interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Model/EncounterccdadispatchTable.php
+++ b/interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Model/EncounterccdadispatchTable.php
@@ -510,9 +510,14 @@ class EncounterccdadispatchTable extends AbstractTableGateway
             $organization_uuid = UuidRegistry::uuidToString($details['facility_uuid']);
         }
 
-        // TODO: get this working later
-//        $referralDate = DateFormatterUtils::dateStringToDateTime($referral['refer_date']);
-        $referralDate = date('YmdHisO');
+        // referral date does not follow the global date settings.  It saves off as Y-m-d so we need to format from there
+        $referralDate = \DateTime::createFromFormat("Y-m-d", $referral['refer_date']);
+        if ($referralDate === false) {
+            $referralDate = date('Y-m-d H:i:sO');
+        } else {
+            $referralDate = $referralDate->format('Y-m-d H:i:sO'); // we get it in the right format even though we have no time element...
+        }
+//        $referralDate = date('YmdHisO');
         $participant = "<participant>
             <date_time>" . xmlEscape($referralDate) . "</date_time>
             <fname>" . xmlEscape($details['fname']) . "</fname>

--- a/interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Model/EncounterccdadispatchTable.php
+++ b/interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Model/EncounterccdadispatchTable.php
@@ -530,7 +530,7 @@ class EncounterccdadispatchTable extends AbstractTableGateway
             <street>" . xmlEscape($details['street']) . "</street>
             <city>" . xmlEscape($details['city']) . "</city>
             <state>" . xmlEscape($details['state']) . "</state>
-            <zip>" . xmlEscape($details['zip']) . "</zip>
+            <postalCode>" . xmlEscape($details['zip']) . "</postalCode>
             <phonew1>" . xmlEscape($details['phonew1']) . "</phonew1>
             <address_use>WP</address_use>
             <type>REFB</type>
@@ -561,7 +561,7 @@ class EncounterccdadispatchTable extends AbstractTableGateway
             <street>" . xmlEscape($details['street']) . "</street>
             <city>" . xmlEscape($details['city']) . "</city>
             <state>" . xmlEscape($details['state']) . "</state>
-            <zip>" . xmlEscape($details['zip']) . "</zip>
+            <postalCode>" . xmlEscape($details['zip']) . "</postalCode>
             <phonew1>" . xmlEscape($details['phonew1']) . "</phonew1>
             <address_use>WP</address_use>
             <type>CALLBCK</type>

--- a/interface/modules/zend_modules/public/xsl/cda.xsl
+++ b/interface/modules/zend_modules/public/xsl/cda.xsl
@@ -2617,16 +2617,18 @@ limitations under the License.
         </xsl:if>
       </xsl:if>
       <!-- time zone. Don't try getting a name for it as that will always fail parts of the year due to daylight savings -->
-      <xsl:choose>
-        <xsl:when test="contains($date, '+')">
-          <xsl:text> +</xsl:text>
-          <xsl:value-of select="substring-after($date, '+')"/>
-        </xsl:when>
-        <xsl:when test="contains($date, '-')">
-          <xsl:text> -</xsl:text>
-          <xsl:value-of select="substring-after($date, '-')"/>
-        </xsl:when>
-      </xsl:choose>
+      <xsl:if test="(string-length($hh) &gt; 1 and not($hh = '00')) or (string-length($mm) &gt; 1 and not($mm = '00'))">
+        <xsl:choose>
+          <xsl:when test="contains($date, '+')">
+            <xsl:text> +</xsl:text>
+            <xsl:value-of select="substring-after($date, '+')"/>
+          </xsl:when>
+          <xsl:when test="contains($date, '-')">
+            <xsl:text> -</xsl:text>
+            <xsl:value-of select="substring-after($date, '-')"/>
+          </xsl:when>
+        </xsl:choose>
+      </xsl:if>
     </xsl:if>
   </xsl:template>
   <!-- convert to lower case -->

--- a/interface/modules/zend_modules/public/xsl/cda.xsl
+++ b/interface/modules/zend_modules/public/xsl/cda.xsl
@@ -160,6 +160,7 @@ limitations under the License.
             <xsl:call-template name="author"/>
             <xsl:call-template name="componentOf"/>
             <xsl:call-template name="participant"/>
+            <xsl:call-template name="referrer-fall-back"></xsl:call-template>
             <xsl:call-template name="informant"/>
             <xsl:call-template name="informationRecipient"/>
             <xsl:call-template name="legalAuthenticator"/>
@@ -936,73 +937,98 @@ limitations under the License.
       </xsl:if>
     </div>
   </xsl:template>
+  <xsl:template xmlns:n1="urn:hl7-org:v3" xmlns:in="urn:lantana-com:inline-variable-data" name="referrer-fall-back">
+    <!-- Here is where we would check to see if we have a participant with /REF or REFB -->
+    <!-- IF we don't we fall back to the care team member PCP -->
+  </xsl:template>
+  <xsl:template xmlns:n1="urn:hl7-org:v3" xmlns:in="urn:lantana-com:inline-variable-data" name="participant-with-title">
+    <xsl:param name="participantRole"></xsl:param>
+    <div class="col-md-6">
+      <h2 class="col-md-6 section-title">
+        <xsl:choose>
+          <xsl:when test="$participantRole">
+            <xsl:call-template name="firstCharCaseUp">
+              <xsl:with-param name="data" select="$participantRole"/>
+            </xsl:call-template>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:text>Participant</xsl:text>
+          </xsl:otherwise>
+        </xsl:choose>
+      </h2>
+      <div class="header-group-content col-md-8">
+        <xsl:if test="n1:functionCode">
+          <xsl:call-template name="show-code">
+            <xsl:with-param name="code" select="n1:functionCode"/>
+          </xsl:call-template>
+        </xsl:if>
+        <xsl:call-template name="show-associatedEntity">
+          <xsl:with-param name="assoEntity" select="n1:associatedEntity"/>
+        </xsl:call-template>
+        <xsl:if test="n1:time">
+          <xsl:if test="n1:time/n1:low">
+            <xsl:text> from </xsl:text>
+            <xsl:call-template name="show-time">
+              <xsl:with-param name="datetime" select="n1:time/n1:low"/>
+            </xsl:call-template>
+          </xsl:if>
+          <xsl:if test="n1:time/n1:high">
+            <xsl:text> to </xsl:text>
+            <xsl:call-template name="show-time">
+              <xsl:with-param name="datetime" select="n1:time/n1:high"/>
+            </xsl:call-template>
+          </xsl:if>
+        </xsl:if>
+        <xsl:if test="position() != last()">
+          <br/>
+        </xsl:if>
+      </div>
+    </div>
+    <div class="col-md-6">
+      <xsl:if test="n1:associatedEntity/n1:addr | n1:associatedEntity/n1:telecom">
+        <h2 class="section-title col-md-6">
+          <xsl:text>Contact</xsl:text>
+        </h2>
+        <div class="col-md-6 header-group-content">
+          <xsl:call-template name="show-contactInfo">
+            <xsl:with-param name="contact" select="n1:associatedEntity"/>
+          </xsl:call-template>
+        </div>
+      </xsl:if>
+    </div>
+  </xsl:template>
   <!-- participant -->
   <xsl:template xmlns:n1="urn:hl7-org:v3" xmlns:in="urn:lantana-com:inline-variable-data" name="participant">
     <div class="container-fluid">
       <xsl:if test="n1:participant">
         <div class="header container-fluid">
           <xsl:for-each select="n1:participant">
-            <xsl:if test="not(n1:associatedEntity/@classCode = 'ECON' or n1:associatedEntity/@classCode = 'NOK')">
-              <xsl:variable name="participtRole">
-                <xsl:call-template name="translateRoleAssoCode">
-                  <xsl:with-param name="classCode" select="n1:associatedEntity/@classCode"/>
-                  <xsl:with-param name="code" select="n1:associatedEntity/n1:code"/>
+            <xsl:choose>
+              <xsl:when test="@typeCode='CALLBCK'">
+                <xsl:call-template name="participant-with-title">
+                  <xsl:with-param name="participantRole" select="'Office Contact'" />
                 </xsl:call-template>
-              </xsl:variable>
-              <div class="col-md-6">
-                <h2 class="col-md-6 section-title">
-                  <xsl:choose>
-                    <xsl:when test="$participtRole">
-                      <xsl:call-template name="firstCharCaseUp">
-                        <xsl:with-param name="data" select="$participtRole"/>
-                      </xsl:call-template>
-                    </xsl:when>
-                    <xsl:otherwise>
-                      <xsl:text>Participant</xsl:text>
-                    </xsl:otherwise>
-                  </xsl:choose>
-                </h2>
-                <div class="header-group-content col-md-8">
-                  <xsl:if test="n1:functionCode">
-                    <xsl:call-template name="show-code">
-                      <xsl:with-param name="code" select="n1:functionCode"/>
+              </xsl:when>
+              <xsl:when test="@typeCode='REFB'">
+                <xsl:call-template name="participant-with-title">
+                  <xsl:with-param name="participantRole" select="'Referring / Transitioning Provider'" />
+                </xsl:call-template>
+              </xsl:when>
+              <xsl:otherwise>
+                <xsl:if test="not(n1:associatedEntity/@classCode = 'ECON' or n1:associatedEntity/@classCode = 'NOK')">
+                  <xsl:variable name="participtRole">
+                    <xsl:call-template name="translateRoleAssoCode">
+                      <xsl:with-param name="classCode" select="n1:associatedEntity/@classCode"/>
+                      <xsl:with-param name="code" select="n1:associatedEntity/n1:code"/>
                     </xsl:call-template>
-                  </xsl:if>
-                  <xsl:call-template name="show-associatedEntity">
-                    <xsl:with-param name="assoEntity" select="n1:associatedEntity"/>
+                  </xsl:variable>
+                  <xsl:call-template name="participant-with-title">
+                    <xsl:with-param name="participantRole" select="$participtRole" />
                   </xsl:call-template>
-                  <xsl:if test="n1:time">
-                    <xsl:if test="n1:time/n1:low">
-                      <xsl:text> from </xsl:text>
-                      <xsl:call-template name="show-time">
-                        <xsl:with-param name="datetime" select="n1:time/n1:low"/>
-                      </xsl:call-template>
-                    </xsl:if>
-                    <xsl:if test="n1:time/n1:high">
-                      <xsl:text> to </xsl:text>
-                      <xsl:call-template name="show-time">
-                        <xsl:with-param name="datetime" select="n1:time/n1:high"/>
-                      </xsl:call-template>
-                    </xsl:if>
-                  </xsl:if>
-                  <xsl:if test="position() != last()">
-                    <br/>
-                  </xsl:if>
-                </div>
-              </div>
-              <div class="col-md-6">
-                <xsl:if test="n1:associatedEntity/n1:addr | n1:associatedEntity/n1:telecom">
-                  <h2 class="section-title col-md-6">
-                    <xsl:text>Contact</xsl:text>
-                  </h2>
-                  <div class="col-md-6 header-group-content">
-                    <xsl:call-template name="show-contactInfo">
-                      <xsl:with-param name="contact" select="n1:associatedEntity"/>
-                    </xsl:call-template>
-                  </div>
                 </xsl:if>
-              </div>
-            </xsl:if>
+              </xsl:otherwise>
+            </xsl:choose>
+
           </xsl:for-each>
         </div>
       </xsl:if>

--- a/src/Events/PatientDocuments/PatientDocumentCreateCCDAEvent.php
+++ b/src/Events/PatientDocuments/PatientDocumentCreateCCDAEvent.php
@@ -71,6 +71,11 @@ class PatientDocumentCreateCCDAEvent
      */
     private $dateTo;
 
+    /**
+     * @var "ccd"|"referral"|"careplan"|"toc"
+     */
+    private $documentType;
+
     public function __construct($pid)
     {
         $this->setPid($pid);
@@ -79,6 +84,7 @@ class PatientDocumentCreateCCDAEvent
         $this->setRecipient("self");
         $this->dateFrom = null;
         $this->dateTo = null;
+        $this->documentType = "ccd";
     }
 
     /**
@@ -271,5 +277,23 @@ class PatientDocumentCreateCCDAEvent
     private function getCcdaStringFormat(array $arr)
     {
         return implode("|", $arr);
+    }
+
+    /**
+     * @return string
+     */
+    public function getDocumentType()
+    {
+        return $this->documentType;
+    }
+
+    /**
+     * @param string $documentType The c-cda document type to generate options are "ccd", "careplan", "toc", "referral"
+     * @return PatientDocumentCreateCCDAEvent
+     */
+    public function setDocumentType($documentType)
+    {
+        $this->documentType = $documentType;
+        return $this;
     }
 }


### PR DESCRIPTION
Added an office contact setting in care coordination.  Added the
participants piece to the header.

Removed the fDate formatting on the document timestamp as PHP was
already sending a timestamp formatted document and the fDate was being
corrupted.  Had to do this to pass ETT validation.

Added a checkbox to let people force the author timestamp value to be
the encounter date time stamp.  This made it possible to override the
timestamps for the document across the three different test scenarios
without having to change it for each individual patient.  Most people
will have this flag turned off, but it sped up the ONC testing instead
of having to set the timestamp on each doc generation (for both b1 and
g9 testing).

@sjpadgett I'm not sure why its trying to merge my first commit again into your branch, not sure if there is an easy way to skip the merge conflicts there.  